### PR TITLE
Fix/date locale with underscore

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-admin-settings/main.js
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-admin-settings/main.js
@@ -21,7 +21,7 @@ const appId = 'AgendaAdminSettingsApplication';
 const lang = eXo && eXo.env.portal.language || 'en';
 
 //should expose the locale ressources as REST API 
-const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portlet.Agenda-${lang}.json`;
+const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portlet.Agenda-${lang.replace('-', '_')}.json`;
 
 export function init() {
   exoi18n.loadLanguageAsync(lang, url).then(i18n => {

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/main.js
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/main.js
@@ -21,7 +21,7 @@ const appId = 'AgendaTimelineApplication';
 const lang = eXo && eXo.env.portal.language || 'en';
 
 //should expose the locale ressources as REST API 
-const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portlet.Agenda-${lang}.json`;
+const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portlet.Agenda-${lang.replace('-', '_')}.json`;
 
 export function init() {
   exoi18n.loadLanguageAsync(lang, url).then(i18n => {

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-user-setting/main.js
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-user-setting/main.js
@@ -21,7 +21,7 @@ const appId = 'AgendaSettingsApplication';
 const lang = eXo && eXo.env.portal.language || 'en';
 
 //should expose the locale ressources as REST API 
-const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portlet.Agenda-${lang}.json`;
+const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portlet.Agenda-${lang.replace('-', '_')}.json`;
 
 export function init() {
   const appElement = document.createElement('div');

--- a/agenda-webapps/src/main/webapp/vue-app/agenda/main.js
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda/main.js
@@ -21,7 +21,7 @@ const appId = 'AgendaApplication';
 const lang = eXo && eXo.env.portal.language || 'en';
 
 //should expose the locale ressources as REST API 
-const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portlet.Agenda-${lang}.json`;
+const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portlet.Agenda-${lang.replace('-', '_')}.json`;
 
 export function init() {
   exoi18n.loadLanguageAsync(lang, url).then(i18n => {


### PR DESCRIPTION
Prior to this change, the I18N Resource bundles of a language with underscore are not load correctly. This fix will send the correct name replacing "-" with "_".